### PR TITLE
(fix) add email scope to facebook auth

### DIFF
--- a/server/auth/facebook/index.js
+++ b/server/auth/facebook/index.js
@@ -15,6 +15,7 @@ router
 
   //callback for api
   .get('/callback', passport.authenticate('facebook', {
+    scope: 'email',
     failureRedirect: '/#/register',
     session: false
   }), function(req, res){


### PR DESCRIPTION
fix #89 
